### PR TITLE
fix: fixed windows prompt colors

### DIFF
--- a/venom.py
+++ b/venom.py
@@ -6,6 +6,9 @@ import random
 import re
 import requests
 
+import colorama
+colorama.init()
+
 
 class bcolors:
     HEADER = '\033[95m'


### PR DESCRIPTION
On windows prompt, the colors doesn't get printed correctly.
<img src="https://user-images.githubusercontent.com/50470310/105636523-8e6b0780-5e47-11eb-9d47-f1228a944d3f.png" width=600 height=300>

But if we put the colorama scheme, the colors works without problems.
<img src="https://user-images.githubusercontent.com/50470310/105636539-9dea5080-5e47-11eb-9d13-5e24f1493854.png" width=600 height=300>